### PR TITLE
Added new step names

### DIFF
--- a/features/clear-string.feature
+++ b/features/clear-string.feature
@@ -5,7 +5,7 @@ Feature: Clear string
   Scenario: Clear single quote string
     When I insert "'foo'"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-;"
     Then I should see "''"
     And the cursor should be between "'" and "'"
@@ -13,7 +13,7 @@ Feature: Clear string
   Scenario: Clear double quote string
     When I insert ""foo""
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-;"
     Then I should see """"
     And the cursor should be between """ and """
@@ -21,15 +21,15 @@ Feature: Clear string
   Scenario: Do not clear empty single quote string
     When I insert "''"
     And I turn on ruby-mode
-    And I go to point "2"
+    And I go to character "'"
     And I press "C-;"
     Then I should see "''"
     And the cursor should be between "'" and "'"
-    
+
   Scenario: Do not clear empty single quote string
     When I insert """"
     And I turn on ruby-mode
-    And I go to point "2"
+    And I go to character """
     And I press "C-;"
     Then I should see """"
     And the cursor should be between """ and """
@@ -37,7 +37,7 @@ Feature: Clear string
   Scenario: Do not clear string when not on a string
     When I insert "foo(:bar)"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I place the cursor between "o" and "o"
     And I press "C-;"
     Then I should see "foo(:bar)"
     And the cursor should be between "fo" and "o"

--- a/features/interpolate.feature
+++ b/features/interpolate.feature
@@ -5,7 +5,7 @@ Feature: Interpolation
   Scenario: Interpolate when in double quote string
     When I insert ""foo""
     And I turn on ruby-mode
-    And I go to point "3"
+    And I place the cursor between "f" and "o"
     And I press "#"
     Then I should see ""f#{}oo""
     And the cursor should be between "{" and "}"
@@ -13,7 +13,7 @@ Feature: Interpolation
   Scenario: Interpolate when in double quote string at the beginning
     When I insert ""foo""
     And I turn on ruby-mode
-    And I go to point "2"
+    And I go to the front of the word "foo"
     And I press "#"
     Then I should see ""#{}foo""
     And the cursor should be between "{" and "}"
@@ -21,7 +21,7 @@ Feature: Interpolation
   Scenario: Interpolate when in double quote string at the end
     When I insert ""foo""
     And I turn on ruby-mode
-    And I go to point "5"
+    And I go to the end of the word "foo"
     And I press "#"
     Then I should see ""foo#{}""
     And the cursor should be between "{" and "}"
@@ -29,7 +29,7 @@ Feature: Interpolation
   Scenario: Interpolate when in shell command
     When I insert "`foo`"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "#"
     Then I should see "`f#{}oo`"
     And the cursor should be between "{" and "}"
@@ -37,7 +37,7 @@ Feature: Interpolation
   Scenario: Interpolate when in shell command at the beginning
     When I insert "`foo`"
     And I turn on ruby-mode
-    And I go to point "2"
+    And I go to the front of the word "foo"
     And I press "#"
     Then I should see "`#{}foo`"
     And the cursor should be between "{" and "}"
@@ -45,7 +45,7 @@ Feature: Interpolation
   Scenario: Interpolate when in shell command at the end
     When I insert "`foo`"
     And I turn on ruby-mode
-    And I go to point "5"
+    And I go to the end of the word "foo"
     And I press "#"
     Then I should see "`foo#{}`"
     And the cursor should be between "{" and "}"
@@ -61,7 +61,7 @@ Feature: Interpolation
   #   And I press "#"
   #   Then I should see "%(f#{}oo)"
   #   And the cursor should be between "{" and "}"
-  #  
+  #
   # Scenario: Interpolate when in percent syntax string at the beginning
   #   When I insert "%(foo)"
   #   And I turn on ruby-mode
@@ -69,7 +69,7 @@ Feature: Interpolation
   #   And I press "#"
   #   Then I should see "%(#{}foo)"
   #   And the cursor should be between "{" and "}"
-  #  
+  #
   # Scenario: Interpolate when in percent syntax string at the end
   #   When I insert "%(foo)"
   #   And I turn on ruby-mode
@@ -81,6 +81,6 @@ Feature: Interpolation
   Scenario: Do not interpolate when in single quote string
     When I insert "'foo'"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "#"
     Then I should see "'f#oo'"

--- a/features/step-definitions/ruby-tools-steps.el
+++ b/features/step-definitions/ruby-tools-steps.el
@@ -1,3 +1,29 @@
 (Then "^ruby-tools-mode should be active$"
       (lambda ()
         (assert ruby-tools-mode nil "Expected `ruby-tools-mode' to be started, but was not.")))
+
+(When "^I go to character \"\\(.+\\)\"$"
+      (lambda (char)
+        (goto-char (point-min))
+        (let ((search (re-search-forward (format "%s" char) nil t))
+              (message "Can not go to character '%s' since it does not exist in the current buffer: %s"))
+          (assert search nil message char (espuds-buffer-contents)))))
+
+(When "^I go to the \\(front\\|back\\) of character \"\\(.+\\)\"$"
+      (lambda (position char)
+        (goto-char (point-min))
+        (let ((search (re-search-forward (format "%s" char) nil t))
+              (message "Can not go to character '%s' since it does not exist in the current buffer: %s"))
+          (assert search nil message char (espuds-buffer-contents))
+          (cond
+           ((string-equal "front" position) (backward-char))
+           ((string-equal "back" position) (forward-char))))))
+
+
+(When "^I go to the \\(front\\|end\\) of the word \"\\(.+\\)\"$"
+      (lambda (pos word)
+        (goto-char (point-min))
+        (let ((search (re-search-forward (format "%s" word) nil t))
+              (message "Can not go to character '%s' since it does not exist in the current buffer: %s"))
+          (assert search nil message word (espuds-buffer-contents))
+          (if (string-equal "front" pos) (backward-word)))))

--- a/features/string-conversion.feature
+++ b/features/string-conversion.feature
@@ -5,7 +5,7 @@ Feature: String conversion
   Scenario: Turn single quote string to double quote string
     When I insert "'foo'"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-""
     Then I should see ""foo""
     And the cursor should be between "f" and "oo"
@@ -13,7 +13,7 @@ Feature: String conversion
   Scenario: Turn single quote string to double quote string in method call
     When I insert "foo('bar')"
     And I turn on ruby-mode
-    And I go to point "7"
+    And I go to character "b"
     And I press "C-""
     Then I should see "foo("bar")"
     And the cursor should be between "b" and "ar"
@@ -21,23 +21,23 @@ Feature: String conversion
   Scenario: Do not turn to single quote string when on single quote string
     When I insert "'foo'"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-'"
     Then I should see "'foo'"
     And the cursor should be between "f" and "oo"
-    
+
   Scenario: Turn double quote string to single quote string
     When I insert ""foo""
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-'"
     Then I should see "'foo'"
     And the cursor should be between "f" and "oo"
-    
+
   Scenario: Turn double quote string to single quote string in method call
     When I insert "foo("bar")"
     And I turn on ruby-mode
-    And I go to point "7"
+    And I go to character "b"
     And I press "C-'"
     Then I should see "foo('bar')"
     And the cursor should be between "b" and "ar"
@@ -45,7 +45,7 @@ Feature: String conversion
   Scenario: Do not turn to double quote string when on double quote string
     When I insert ""foo""
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-""
     Then I should see ""foo""
     And the cursor should be between "f" and "oo"
@@ -53,7 +53,7 @@ Feature: String conversion
   Scenario: Turn empty single quote string to empty double quote string
     When I insert "''"
     And I turn on ruby-mode
-    And I go to point "2"
+    And I go to character "'"
     And I press "C-""
     Then I should see """"
     And the cursor should be between """ and """
@@ -61,7 +61,7 @@ Feature: String conversion
   Scenario: Turn empty double quote string to empty single quote string
     When I insert """"
     And I turn on ruby-mode
-    And I go to point "2"
+    And I go to character """
     And I press "C-'"
     Then I should see "''"
     And the cursor should be between "'" and "'"
@@ -69,7 +69,7 @@ Feature: String conversion
   Scenario: Turn single quote string with quotes to double quote string
     When I insert "'foo \' bar'"
     And I turn on ruby-mode
-    And I go to point "4"
+    And I go to character "o"
     And I press "C-""
     Then I should see ""foo ' bar""
     And the cursor should be between ""fo" and "o ' bar""
@@ -77,7 +77,7 @@ Feature: String conversion
   Scenario: Turn single quote string with double quote inside to double quote string
     When I insert "'foo " bar'"
     And I turn on ruby-mode
-    And I go to point "4"
+    And I go to character "o"
     And I press "C-""
     Then I should see ""foo \" bar""
     And the cursor should be between ""fo" and "o \" bar""
@@ -85,7 +85,7 @@ Feature: String conversion
   Scenario: Turn double quote string with quotes to single quote string
     When I insert ""foo \" bar""
     And I turn on ruby-mode
-    And I go to point "4"
+    And I go to character "o"
     And I press "C-'"
     Then I should see "'foo " bar'"
     And the cursor should be between "'fo" and "o " bar'"
@@ -93,7 +93,7 @@ Feature: String conversion
   Scenario: Turn double quote string with single quote inside to single quote string
     When I insert ""foo ' bar""
     And I turn on ruby-mode
-    And I go to point "4"
+    And I go to character "o"
     And I press "C-'"
     Then I should see "'foo \' bar'"
     And the cursor should be between "'fo" and "o \' bar'"

--- a/features/string-to-symbol.feature
+++ b/features/string-to-symbol.feature
@@ -5,7 +5,7 @@ Feature: String To Symbol
   Scenario: Turn single quote string to symbol
     When I insert "'foo'"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-:"
     Then I should see ":foo"
     And the cursor should be between "f" and "oo"
@@ -13,7 +13,7 @@ Feature: String To Symbol
   Scenario: Turn double quote string to symbol
     When I insert ""foo""
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-:"
     Then I should see ":foo"
     And the cursor should be between "f" and "oo"
@@ -21,7 +21,7 @@ Feature: String To Symbol
   Scenario: Turn single quote string in method argument to symbol
     When I insert "foo('bar')"
     And I turn on ruby-mode
-    And I go to point "7"
+    And I go to character "b"
     And I press "C-:"
     Then I should see "foo(:bar)"
     And the cursor should be between "b" and "ar"
@@ -29,7 +29,7 @@ Feature: String To Symbol
   Scenario: Turn double quote string in method argument to symbol
     When I insert "foo("bar")"
     And I turn on ruby-mode
-    And I go to point "7"
+    And I go to character "b"
     And I press "C-:"
     Then I should see "foo(:bar)"
     And the cursor should be between "b" and "ar"
@@ -37,23 +37,26 @@ Feature: String To Symbol
   Scenario: Turn single quote string with underscores to symbol
     When I insert "'foo_bar'"
     And I turn on ruby-mode
-    And I go to point "5"
+    And I place the cursor between "o" and "_"
     And I press "C-:"
     Then I should see ":foo_bar"
     And the cursor should be between "foo" and "_bar"
-    
+
   Scenario: Turn string to symbol when at beginning of string
     When I insert "'foo'"
     And I turn on ruby-mode
-    And I go to point "2"
+    # And I go to the front of character "f"
+    And I go to character "'"
+    # And I go in front of the c
+    # And I place the cursor between "o" and "o"
     And I press "C-:"
     Then I should see ":foo"
     And the cursor should be before "foo"
-    
+
   Scenario: Turn string to symbol when at end of string
     When I insert "'foo'"
     And I turn on ruby-mode
-    And I go to point "5"
+    And I go to the end of the word "foo"
     And I press "C-:"
     Then I should see ":foo"
     And the cursor should be after "foo"
@@ -61,7 +64,7 @@ Feature: String To Symbol
   Scenario: Do not turn symbol to string when not on a string
     When I insert "foo('bar')"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I place the cursor between "o" and "o"
     And I press "C-:"
     Then I should see "foo('bar')"
     And the cursor should be between "fo" and "o"
@@ -69,7 +72,7 @@ Feature: String To Symbol
   Scenario: Do not turn symbol to string when invalid symbol characters in string
     When I insert "'foo bar'"
     And I turn on ruby-mode
-    And I go to point "4"
+    And I place the cursor between "o" and "o"
     And I press "C-:"
     Then I should see "'foo bar'"
     And the cursor should be between "fo" and "o b"
@@ -77,7 +80,7 @@ Feature: String To Symbol
  Scenario: Turn empty string to symbol
     When I insert "''"
     And I turn on ruby-mode
-    And I go to point "2"
+    And I place the cursor between "'" and "'"
     And I press "C-:"
     Then I should see ":"
     And the cursor should be after ":"

--- a/features/symbol-to-string.feature
+++ b/features/symbol-to-string.feature
@@ -5,7 +5,7 @@ Feature: Symbol To String
   Scenario: Turn symbol to single quote string
     When I insert ":foo"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-'"
     Then I should see "'foo'"
     And the cursor should be between "f" and "oo"
@@ -13,7 +13,7 @@ Feature: Symbol To String
   Scenario: Turn symbol to double quote string
     When I insert ":foo"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "f"
     And I press "C-""
     Then I should see ""foo""
     And the cursor should be between "f" and "oo"
@@ -21,7 +21,7 @@ Feature: Symbol To String
   Scenario: Turn symbol in method argument to single quote string
     When I insert "foo(:bar)"
     And I turn on ruby-mode
-    And I go to point "7"
+    And I go to character "b"
     And I press "C-'"
     Then I should see "foo('bar')"
     And the cursor should be between "b" and "ar"
@@ -29,23 +29,23 @@ Feature: Symbol To String
   Scenario: Turn symbol in method argument to double quote string
     When I insert "foo(:bar)"
     And I turn on ruby-mode
-    And I go to point "7"
+    And I go to character "b"
     And I press "C-""
     Then I should see "foo("bar")"
     And the cursor should be between "b" and "ar"
-    
+
   Scenario: Turn symbol in to string when at beginning of symbol
     When I insert "foo(:bar)"
     And I turn on ruby-mode
-    And I go to point "6"
+    And I go to character ":"
     And I press "C-'"
     Then I should see "foo('bar')"
     And the cursor should be before "bar"
-    
+
   Scenario: Turn symbol in to string when at end of symbol
     When I insert "foo(:bar)"
     And I turn on ruby-mode
-    And I go to point "9"
+    And I go to the end of the word "bar"
     And I press "C-'"
     Then I should see "foo('bar')"
     And the cursor should be after "bar"
@@ -53,7 +53,7 @@ Feature: Symbol To String
   Scenario: Do not turn symbol to string when not on symbol
     When I insert "foo(:bar)"
     And I turn on ruby-mode
-    And I go to point "3"
+    And I go to character "o"
     And I press "C-'"
     Then I should see "foo(:bar)"
     And the cursor should be between "fo" and "o"
@@ -61,7 +61,7 @@ Feature: Symbol To String
   Scenario: Do not turn symbol to string when symbol in string
     When I insert "'foo :bar baz'"
     And I turn on ruby-mode
-    And I go to point "8"
+    And I go to character "b"
     And I press "C-'"
     Then I should see "'foo :bar baz'"
     And the cursor should be between "oo :b" and "ar ba"
@@ -69,7 +69,7 @@ Feature: Symbol To String
   Scenario: Turn empty symbol to string
     When I insert ":"
     And I turn on ruby-mode
-    And I go to point "2"
+    And I go to character ":"
     And I press "C-'"
     Then I should see "''"
     And the cursor should be between "'" and "'"


### PR DESCRIPTION
I found steps like:

  And I go to point "3"

too 'robotic'. I don't think that as a Emacs user I ever think in
points of a buffer. So I've added steps which are more natural to me.

Next point as discussed over email, taking these steps:

Scenario: Turn single quote string to double quote string
  When I insert "'foo'"
  And I turn on ruby-mode
  And I go to point "3"
  And I press "C-""
  Then I should see ""foo""
  And the cursor should be between "f" and "oo"

To something like this:

Scenario: Turn single quote string to double quote string
  When I insert the single quote string "foo"
  And I place the cursor on the string "foo"
  And I press "C-""
  Then I should see the double quote string "foo"
  And the cursor should be on the string "foo"

I'm not sure how much would be gained by stating "insert single quote string".

Maybe a better convention would be to change the **When I insert** step to not only take words enclosed in double quotes, but to have it written as:

**When I insert:**

and anything following the **:** is considered input.

Just an idea...
