### PR TITLE
Convert Symbols and Strings on sexp boundaries

### DIFF
--- a/features/string-to-symbol.feature
+++ b/features/string-to-symbol.feature
@@ -10,6 +10,14 @@ Feature: String To Symbol
     Then I should see ":foo"
     And the cursor should be between "f" and "oo"
 
+  Scenario: Turn single quote string to symbol when the cursor is before quote
+    When I insert "'foo'"
+    And I turn on ruby-mode
+    And I go to character "'"
+    And I press "C-:"
+    Then I should see ":foo"
+    And the cursor should be before "foo"
+
   Scenario: Turn double quote string to symbol
     When I insert ""foo""
     And I turn on ruby-mode
@@ -81,6 +89,14 @@ Feature: String To Symbol
     When I insert "''"
     And I turn on ruby-mode
     And I place the cursor between "'" and "'"
+    And I press "C-:"
+    Then I should see ":"
+    And the cursor should be after ":"
+
+ Scenario: Turn empty string to symbol when the cursor is before quote
+    When I insert "''"
+    And I turn on ruby-mode
+    And I go to character "'"
     And I press "C-:"
     Then I should see ":"
     And the cursor should be after ":"

--- a/features/symbol-to-string.feature
+++ b/features/symbol-to-string.feature
@@ -10,6 +10,14 @@ Feature: Symbol To String
     Then I should see "'foo'"
     And the cursor should be between "f" and "oo"
 
+  Scenario: Turn symbol to single quote string when the cursor is before colon
+    When I insert ":foo"
+    And I turn on ruby-mode
+    And I go to character ":"
+    And I press "C-'"
+    Then I should see "'foo'"
+    And the cursor should be before "foo"
+
   Scenario: Turn symbol to double quote string
     When I insert ":foo"
     And I turn on ruby-mode
@@ -67,6 +75,14 @@ Feature: Symbol To String
     And the cursor should be between "oo :b" and "ar ba"
 
   Scenario: Turn empty symbol to string
+    When I insert ":"
+    And I turn on ruby-mode
+    And I go to character ":"
+    And I press "C-'"
+    Then I should see "''"
+    And the cursor should be between "'" and "'"
+
+  Scenario: Turn empty symbol to string when the cursor is before colon
     When I insert ":"
     And I turn on ruby-mode
     And I go to character ":"


### PR DESCRIPTION
In relation to #10. 

In addition to the current behavior this will allow one to toggle `String`s/`Symbol`s based on sexp boundaries.

I want to add more tests but need clarification on the intention of the ecukes steps as they are not as they appear. 

The `And I go to character` step. Given `":foo"`, saying `And I go to character ":"` will result in `(point)` being on `f`. Is this what you want? If I'm going to `:` then `(point)` should be on `:`, not `f`.

The `And I go to the front of character ":"` step resolves the above, as it will put `(point)` on `:`, but when it's used the tests fail. Even though the code works interactively none of the text in the test is replaced. I see the step is not used in the current tests so is this a known issue?
