### PR TITLE
(ruby-tools-interpolate) Trigger in more places

### DIFF
--- a/ruby-tools.el
+++ b/ruby-tools.el
@@ -109,7 +109,9 @@
   (when (or
          (ruby-tools-looking-around "\"[^\"\n]*" "[^\"\n]*\"")
          (ruby-tools-looking-around "`[^`\n]*"   "[^`\n]*`")
-         (ruby-tools-looking-around "%([^(\n]*"  "[^)\n]*)"))
+         (ruby-tools-looking-around "%([^(\n]*"  "[^)\n]*)")
+         (ruby-tools-looking-around "%\[[^(\n]*"  "[^)\n]*\]")
+         (ruby-tools-looking-around "%\{[^(\n]*"  "[^)\n]*\}"))
     (cond (mark-active
            (goto-char (region-beginning))
            (insert "{")


### PR DESCRIPTION
Adds support for more delimiters:
- `%[#]` => `%[#{}]`
- `%{#}` => `%{#{}}`